### PR TITLE
style: add and apply ruff.toml

### DIFF
--- a/demo/01_tap.py
+++ b/demo/01_tap.py
@@ -3,9 +3,10 @@
 # details: https://mwatelescope.atlassian.net/wiki/spaces/MP/pages/24970532/MWA+ASVO+VO+Services
 # and https://mwatelescope.atlassian.net/wiki/spaces/MP/pages/24970424/TAP+mwa.observation+Schema+and+Examples
 
+from sys import argv, stderr
+
 import pyvo
 from astropy.time import Time, TimeDelta
-from sys import stderr, argv
 
 if not argv:
     print(
@@ -49,18 +50,7 @@ ORDER BY obs_id DESC
 obs["config"] = obs["mwa_array_configuration"].str.split(" ").str[-1]
 obs["gigabytes"] = obs["total_archived_data_bytes"] / 1e9
 print(f"{len(obs)} results. preview:", file=stderr)
-print(
-    obs[
-        [
-            "obs_id",
-            "starttime_utc",
-            "obsname",
-            "config",
-            "gigabytes",
-        ]
-    ],
-    file=stderr,
-)
+print(obs[["obs_id", "starttime_utc", "obsname", "config", "gigabytes"]], file=stderr)
 
 out_obsids = "obsids.csv"
 if len(argv) > 1:

--- a/demo/03_mwalib.py
+++ b/demo/03_mwalib.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # get the channel and antenna information from the metafits file
 
+import sys
+
 from mwalib import MetafitsContext
 from pandas import DataFrame
-import sys
 
 
 def get_channel_df(ctx: MetafitsContext):
@@ -14,7 +15,9 @@ def get_channel_df(ctx: MetafitsContext):
         "chan_centre_hz",
         "chan_end_hz",
     ]
-    df = DataFrame({h: [getattr(c, h) for c in ctx.metafits_coarse_chans] for h in header})
+    df = DataFrame(
+        {h: [getattr(c, h) for c in ctx.metafits_coarse_chans] for h in header}
+    )
     return df
 
 
@@ -35,7 +38,9 @@ def get_antenna_df(ctx: MetafitsContext):
     for h in rfheader:
         df[h] = [getattr(a.rfinput_x, h) for a in ctx.antennas]
     # rec_type is "ReceiverType.RRI", I want just "RRI"
-    df["rec_type"] = [str(a.rfinput_x.rec_type).replace("ReceiverType.", "") for a in ctx.antennas]
+    df["rec_type"] = [
+        str(a.rfinput_x.rec_type).replace("ReceiverType.", "") for a in ctx.antennas
+    ]
     return df
 
 

--- a/demo/09_peel2reg.py
+++ b/demo/09_peel2reg.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-import numpy as np
-
 import json
-from argparse import ArgumentParser
 import os
+from argparse import ArgumentParser
+
+import numpy as np
 
 
 def sanitize_json(jstr):
@@ -45,7 +45,7 @@ def main():
     src_names = []
     offsets_base, ext = os.path.splitext(args.offsets)
     if ext == ".json":
-        with open(args.offsets, "r") as h:
+        with open(args.offsets) as h:
             iono_consts = json.loads(sanitize_json(h.read()))
         alphas = []
         betas = []
@@ -71,13 +71,7 @@ def main():
     )
     with open(reg_file, "w") as h:
         h.write("J2000;\n")
-        for (
-            ra,
-            dec,
-            src_name,
-            alpha,
-            beta,
-        ) in zip(
+        for ra, dec, src_name, alpha, beta in zip(
             ras,
             decs,
             src_names,
@@ -87,7 +81,7 @@ def main():
             angle = np.arctan2(beta, alpha) * 180 / np.pi
             length = np.sqrt(alpha**2 + beta**2)
             h.write(
-                f"vector {ra}d {dec}d {length*1000}d {angle}d # text={{{src_name}}}\n"
+                f"vector {ra}d {dec}d {length * 1000}d {angle}d # text={{{src_name}}}\n"
             )
     print(f"Wrote {reg_file}")
 

--- a/demo/10_phase.py
+++ b/demo/10_phase.py
@@ -4,20 +4,19 @@
 # https://colab.research.google.com/drive/1FT-yR4kDqHdEDkOMfu1p-92ydYZVZEqN
 # by Danny C. Price
 
-import numpy as np
-from numpy import pi
-
-import sys
-from SSINS import SS
-from os.path import dirname
-from pyuvdata import UVData
-from astropy.coordinates import Angle
-from astropy import units as u
-from astropy.units.core import UnitsError
-import traceback
-import matplotlib as mpl
-from matplotlib import pyplot as plt
 import re
+import sys
+import traceback
+from os.path import dirname
+
+import numpy as np
+from astropy import units as u
+from astropy.coordinates import Angle
+from astropy.units.core import UnitsError
+from numpy import pi
+from SSINS import SS
+
+from pyuvdata import UVData
 
 
 def get_parser():
@@ -62,7 +61,7 @@ def get_suffix(args):
 
 def _parse_angle_d2r(angle):
     """
-    specify an angle in degrees, or another unit but return it in radians
+    Specify an angle in degrees, or another unit but return it in radians
     """
     try:
         angle = Angle(angle)
@@ -94,7 +93,13 @@ def phase_resample(uvd: UVData, args):
     if cat_name is None:
         pass
     elif cat_name == "zenith":
-        uvd.phase(lon=0, lat=pi / 2, cat_name=cat_name, phase_frame="altaz", cat_type="driftscan")
+        uvd.phase(
+            lon=0,
+            lat=pi / 2,
+            cat_name=cat_name,
+            phase_frame="altaz",
+            cat_type="driftscan",
+        )
     elif m := re.match(r"ra=(.*),dec=(.*)", cat_name):
         ra, dec = m.groups()
         uvd.phase(

--- a/demo/11_allsky.py
+++ b/demo/11_allsky.py
@@ -4,21 +4,21 @@
 # https://colab.research.google.com/drive/1FT-yR4kDqHdEDkOMfu1p-92ydYZVZEqN
 # by Danny C. Price
 
-import numpy as np
-from numpy import pi
-
+import itertools
 import sys
-from SSINS import SS
+import traceback
 from os.path import dirname
-from pyuvdata import UVData
+
+import matplotlib as mpl
+import numpy as np
 from astropy.coordinates import EarthLocation
+from astropy.io import fits
 from astropy.time import Time
 from astropy.wcs import WCS
-from astropy.io import fits
-import traceback
-import matplotlib as mpl
-import itertools
 from matplotlib import pyplot as plt
+from SSINS import SS
+
+from pyuvdata import UVData
 
 
 def select_vis_matrix(uvd: UVData, **select_kwargs) -> np.ndarray:
@@ -32,7 +32,8 @@ def select_vis_matrix(uvd: UVData, **select_kwargs) -> np.ndarray:
         uvd: Input UVData object
         select_kwargs: args for UVData.select.
 
-    Returns:
+    Returns
+    -------
         V (np.ndarray): (N_ant × N_ant × N_freq × N_pol) correlation matrix <c64>
     """
     sel = uvd.select(**select_kwargs, inplace=False)
@@ -45,7 +46,9 @@ def select_vis_matrix(uvd: UVData, **select_kwargs) -> np.ndarray:
     ix, iy = np.triu_indices(sel.Nants_data, 1)
 
     # Create empty Na x Na x Nf x Np matrix
-    V = np.zeros((sel.Nants_data, sel.Nants_data, sel.Nfreqs, sel.Npols), dtype="complex64")
+    V = np.zeros(
+        (sel.Nants_data, sel.Nants_data, sel.Nfreqs, sel.Npols), dtype="complex64"
+    )
 
     # Fill in the upper triangle
     V[ix, iy, ...] = np.conj(d)

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,49 @@
+# Contents for ruff.toml (based on pyuvdata's pyproject.toml)
+
+[lint]
+select = [
+    "E",   # pycodestyle
+    "W",   # pycodestyle warnings
+    "F",   # Pyflakes
+    "D",   # pydocstyle
+    "UP",  # pyupgrade
+    "B",   # flake8-bugbear
+    "A",   # flake8-builtins
+    "C4",  # flake8-comprehensions
+    "N",   # pep8-naming
+    "SIM", # flake8-simplify
+    "I",   # isort
+    # "C90", # McCabe complexity. Consider for the future
+]
+ignore = [
+    "N806",   # non-lowercase variable (we use N* for axes lengths)
+    "B028",   # no-explicit-stacklevel for warnings
+    "SIM108", # prefer ternary opperators. I find them difficult to read.
+    "D203",   # one-blank-line-before-class. we use two.
+    "D212",   # multi-line-summary-first-line. We put it on the second line.
+]
+
+[lint.per-file-ignores]
+"tests/*" = ["D"] # Don't require docstrings for tests
+"docs/*.py" = [
+    "D",
+    "A",
+] # Don't require docstrings or worry about builtins for docs
+"setup.py" = ["D"] # Don't require docstrings for setup.py
+
+[format]
+skip-magic-trailing-comma = true
+
+[lint.pycodestyle]
+max-line-length = 88
+
+# consider setting this in the future
+# [lint.mccabe]
+# max-complexity = 30
+
+[lint.isort]
+combine-as-imports = true
+split-on-trailing-comma = false
+
+[lint.pydocstyle]
+convention = "numpy"


### PR DESCRIPTION
This commit adds a `ruff.toml` configuration to the project as a precursor to using a `pyproject.toml`.

The configuration is based on pyuvdata's ruff section of their pyproject.toml with site-specific options removed.

The configuration was then applied to the source with:

```bash
ruff format demo/
ruff check --fix demo/
```
The resulting automated changes are also included in this commit.